### PR TITLE
Refactor pallet engine to pure data processing, remove I/O

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,9 @@ ignore = [
     "INP001", # (File `docs/conf.py` is part of an implicit namespace package. Add an `__init__.py`.) - Docs are not modules
 ]
 "tests/*" = [
-    "S101",   # (Use of `assert` detected) - Yes, that's the point
+    "S101",    # (Use of `assert` detected) - Yes, that's the point
+    "D103",    # (Missing docstring in public function) - Test names are docs
+    "PLR2004", # (Magic value used in comparison) - Tests assert against literals
 ]
 
 [tool.ruff.lint.isort]

--- a/src/palletinator/__init__.py
+++ b/src/palletinator/__init__.py
@@ -1,1 +1,16 @@
-"""Pallet-inator."""
+"""Pallet-inator: a structured-data pallet program processor."""
+
+from palletinator.engine import process
+from palletinator.inputs import ColumnNames, Request
+from palletinator.models import Cell, Column, Pallet, PalletType, Side
+
+__all__ = [
+    "Cell",
+    "Column",
+    "ColumnNames",
+    "Pallet",
+    "PalletType",
+    "Request",
+    "Side",
+    "process",
+]

--- a/src/palletinator/engine.py
+++ b/src/palletinator/engine.py
@@ -1,64 +1,55 @@
-"""Pallet Program."""
+"""Pallet processing engine.
 
-import base64
+Turns a pallet-program CSV export into a structured list of `Pallet`
+objects. The engine performs no I/O: it does not contact a database,
+fetch images, render PDFs, or send mail. Callers are responsible for
+enriching cells (using each cell's ``photo_lookup_key``) and for any
+downstream presentation.
+"""
+
 import csv
-from dataclasses import asdict, dataclass
-from enum import Enum, auto
-from io import BytesIO, StringIO
-from typing import Self
+from dataclasses import dataclass
+from io import StringIO
+from typing import TYPE_CHECKING, Self
 
-import httpx
-from msgraph.generated.models.file_attachment import FileAttachment
-from PIL import Image
-from sqlalchemy import select
-from weasyprint import CSS, HTML
+from palletinator.models import Cell, Column, Pallet, PalletType, Side
 
-from core.common.mailer import send_mail
-from core.common.templating import template_environment
-from core.data import OnSiteDesign, Session
-from core.external.local_api import local_api_client
-from core.models.pallet_program import ColumnNames, PDFsRequest
+if TYPE_CHECKING:
+    from palletinator.inputs import ColumnNames, Request
+
+_FIVE_COLUMN_TRIGGER = 5
+_MAX_CELLS_PER_COLUMN = 4
 
 
-def get_image_for_design(design_number: int, size: tuple[int, int] | None = None) -> str:
-    """Find and load to base64."""
-    image_bytes = local_api_client.get_design_image(design_number)
+def process(request: Request) -> list[Pallet]:
+    """Process a pallet-program CSV export into structured pallet data.
 
-    image = Image.open(BytesIO(image_bytes))
-    if size:
-        image.thumbnail(size)
+    Parameters
+    ----------
+    request
+        The CSV payload and the column-name mapping describing where
+        each logical field lives in the export.
 
-    buffered = BytesIO()
-    image.save(buffered, format="PNG")
-    buffered.seek(0)
-
-    return base64.b64encode(buffered.getvalue()).decode()
-
-
-def _find_numbers_in_text(text: float | str) -> list[int]:
-    if isinstance(text, float | int):
-        return [int(text)]
-    return [int(char) for char in text if char.isdigit()]
-
-
-class PalletType(Enum):
-    """Type of pallet."""
-
-    FULL = auto()
-    HALF = auto()
-    TOWER = auto()
+    Returns
+    -------
+    list[Pallet]
+        One `Pallet` per row group in the export.
+    """
+    raw_rows = list(csv.DictReader(StringIO(request.csv_data)))
+    rows = [_Row.from_dict(raw, request.column_names) for raw in raw_rows]
+    return [_build_pallet(group) for group in _group_rows(rows)]
 
 
 @dataclass(frozen=True, slots=True)
-class Row:
-    """A sheet row."""
+class _Row:
+    """An internal parsed CSV row."""
 
-    callout: str
     parent_zppk: str
     baby_zppk: str
     team_key: str
     team_name: str
     requested_pallet_count: int
+    callout: str
     dc_target: str
     color_description: str
     logo_description: str
@@ -66,168 +57,106 @@ class Row:
     columns: list[int]
 
     @classmethod
-    def build_from(cls: type[Self], data: dict, column_names: ColumnNames) -> Self:  # type: ignore[type-arg]
-        """Build `cls` from `dict`."""
-        if column_names.callout is not None:
-            callout = "CLC CREATIVE CORRUGATE" if data.get(column_names.callout) == "Yes" else ""
-        else:
-            callout = ""
+    def from_dict(cls: type[Self], data: dict[str, str], names: ColumnNames) -> Self:
+        """Build a row from a `csv.DictReader` record."""
+        callout = ""
+        if names.callout is not None and data.get(names.callout) == "Yes":
+            callout = "CLC CREATIVE CORRUGATE"
 
-        dc_target = data.get(column_names.date_column) if column_names.date_column is not None else ""
+        dc_target = ""
+        if names.date_column is not None:
+            dc_target = data.get(names.date_column) or ""
 
         return cls(
-            parent_zppk=data.get(column_names.parent_zppk),  # type: ignore[arg-type] # ty: ignore[invalid-argument-type]
-            baby_zppk=data.get(column_names.baby_zppk),  # type: ignore[arg-type] # ty: ignore[invalid-argument-type]
-            team_key=data.get(column_names.team_key),  # type: ignore[arg-type] # ty: ignore[invalid-argument-type]
-            team_name=data.get(column_names.team_name),  # type: ignore[arg-type] # ty: ignore[invalid-argument-type]
-            requested_pallet_count=int(data.get(column_names.requested_pallet_count) or 0),
-            dc_target=dc_target,  # type: ignore[arg-type] # ty: ignore[invalid-argument-type]
-            color_description=data.get(column_names.color_description),  # type: ignore[arg-type] # ty: ignore[invalid-argument-type]
-            logo_description=data.get(column_names.logo_description),  # type: ignore[arg-type] # ty: ignore[invalid-argument-type]
+            parent_zppk=data.get(names.parent_zppk) or "",
+            baby_zppk=data.get(names.baby_zppk) or "",
+            team_key=data.get(names.team_key) or "",
+            team_name=data.get(names.team_name) or "",
+            requested_pallet_count=int(data.get(names.requested_pallet_count) or 0),
             callout=callout,
-            sides=_find_numbers_in_text(data.get(column_names.side, "1")),
-            columns=_find_numbers_in_text(data.get(column_names.column)),  # type: ignore[arg-type] # ty: ignore[invalid-argument-type]
+            dc_target=dc_target,
+            color_description=data.get(names.color_description) or "",
+            logo_description=data.get(names.logo_description) or "",
+            sides=_extract_numbers(data.get(names.side) or "1"),
+            columns=_extract_numbers(data.get(names.column) or ""),
         )
 
 
-@dataclass(frozen=True, slots=True)
-class PalletConfig:
-    """Configuration of a pallet build."""
-
-    zppk: str
-    team_key: str
-    team_name: str
-    callout: str
-    dc_target: str
-    pallet_type: PalletType
-    required_count: int
-    sides: list[list[str]]
-
-    @classmethod
-    def build_from(cls: type[Self], rows: list[Row]) -> Self:
-        """Build `cls` from `dict`."""
-        last = rows.pop()
-
-        return cls(
-            callout=last.callout,
-            dc_target=last.dc_target,
-            zppk=rows[-1].parent_zppk,
-            team_name=rows[-1].team_name,
-            team_key=rows[-1].team_key,
-            pallet_type=PalletType.TOWER,
-            required_count=last.requested_pallet_count,
-            sides=flip_pallet_sides(parse_sides(rows, repeat_columns=False)),
-        )
+def _extract_numbers(text: str) -> list[int]:
+    """Pull the digit characters out of `text` as a list of single-digit ints."""
+    return [int(char) for char in text if char.isdigit()]
 
 
-def parse_sides(  # noqa: C901,PLR0912 -- split this up
-    rows: list[Row],
-    *,
-    repeat_columns: bool = False,
-) -> list[list[str]]:
-    """Parse sides for half pallet."""
-    column_designs_cache = {}
-    sides = {}  # type: ignore[var-annotated]
+def _group_rows(rows: list[_Row]) -> list[list[_Row]]:
+    """Split rows into groups, terminating on a non-zero `requested_pallet_count`."""
+    groups: list[list[_Row]] = []
+    current: list[_Row] = []
     for row in rows:
-        for side in row.sides:
-            if row.columns[0] == 5:  # noqa: PLR2004 -- confirm what this does
-                repeat_columns = True
-                columns = [2] if side % 2 == 0 else [3]
-            else:
-                columns = row.columns
-            columns = list(range(1, columns[0] + 1)) if repeat_columns else columns
-            for column in columns:
-                if side not in sides:
-                    sides[side] = {}
-                if column not in sides[side]:
-                    sides[side][column] = []
-                    column_designs_cache[side, column] = " ".join(
-                        (
-                            row.logo_description[:7],
-                            row.color_description.replace(",", ""),
-                            row.team_key,
-                        ),
-                    )
-                sides[side][column].append(row.baby_zppk)
-
-    last_used_design_number = None
-    last_used_design_image = None
-    output = []
-    for side_key in sorted(sides.keys()):
-        current_side = sides[side_key]
-        for column_key in sorted(current_side.keys()):
-            row = current_side[column_key]
-            if len(row) > 4:  # noqa: PLR2004 -- temp
-                row = row[-4:]
-            with Session() as session:
-                key_ = column_designs_cache[side_key, column_key]
-                design_number = session.scalars(
-                    select(OnSiteDesign.number).where(OnSiteDesign.title.ilike(f"{key_}%")),
-                ).first()
-            if design_number and design_number == last_used_design_number:
-                image = last_used_design_image
-            else:
-                last_used_design_number = design_number
-                if design_number is not None:
-                    try:
-                        image = get_image_for_design(design_number, (70, 70))
-                    except Exception:  # noqa: BLE001
-                        image = f"{key_=} {design_number=}"
-                else:
-                    image = f"{key_=} {design_number=}"
-                last_used_design_image = image
-            row.append(str(image))
-            output.append(row)
-    return output
-
-
-def flip_pallet_sides(data: list[list[str]]) -> list[list[str]]:
-    """Flip the sides on a pallet."""
-    heads = ["XS (13) / S (13)", "M (30)", "L (32)", "XL (20)", "IMAGE"]
-    output = []
-    for index, head in enumerate(heads):
-        output.append([head] + [lst[index] for lst in data])
-    return output
-
-
-async def generate_pallet_detail_sheets(
-    pdfs_request: PDFsRequest,
-) -> None:
-    """Build and send a report."""
-    raw_rows = list(csv.DictReader(StringIO(pdfs_request.file_data)))
-
-    rows = [Row.build_from(raw_row, pdfs_request.column_names) for raw_row in raw_rows]
-    row_groups = []
-    group = []
-    for row in rows:
-        group.append(row)
+        current.append(row)
         if row.requested_pallet_count != 0:
-            row_groups.append(group)
-            group = []
+            groups.append(current)
+            current = []
+    return groups
 
-    pallet_configs = [PalletConfig.build_from(row_group) for row_group in row_groups]
 
-    html_template = template_environment.get_template("pallet-program/pallet.html.j2")
-    async with httpx.AsyncClient() as client:
-        response = await client.get("https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css")
-    cached_css = CSS(string=response.text)
+def _build_pallet(group: list[_Row]) -> Pallet:
+    """Build a `Pallet` from a single row group."""
+    last = group[-1]
+    header = group[-2] if len(group) > 1 else last
+    body = group[:-1] if len(group) > 1 else group
 
-    documents = []
-    for pallet_config in pallet_configs:
-        html = HTML(string=html_template.render(asdict(pallet_config)))
-        documents.append(html.render(stylesheets=[cached_css]))
-    all_pages = [page for document in documents for page in document.pages]
-    bytes_ = documents[0].copy(all_pages).write_pdf()
-
-    attachment = FileAttachment(
-        name="details.pdf",
-        content_type="application/pdf",
-        content_bytes=bytes_,
+    return Pallet(
+        zppk=header.parent_zppk,
+        team_key=header.team_key,
+        team_name=header.team_name,
+        callout=last.callout,
+        dc_target=last.dc_target,
+        pallet_type=PalletType.TOWER,
+        required_count=last.requested_pallet_count,
+        sides=_build_sides(body),
     )
 
-    await send_mail(
-        recipient_addresses=[pdfs_request.email_address],
-        subject="Details PDFs",
-        content="<p>Please see your PDFs attached.</p>",
-        attachments=[attachment],
+
+def _build_sides(rows: list[_Row]) -> list[Side]:
+    """Bucket rows by `(side, column)` and emit `Side` objects in order."""
+    buckets: dict[int, dict[int, list[_Row]]] = {}
+    keys: dict[tuple[int, int], str] = {}
+    repeat_columns = False
+    for row in rows:
+        for side_num in row.sides:
+            if row.columns and row.columns[0] == _FIVE_COLUMN_TRIGGER:
+                repeat_columns = True
+                column_set = [2] if side_num % 2 == 0 else [3]
+            else:
+                column_set = row.columns
+            if not column_set:
+                continue
+            if repeat_columns:
+                column_set = list(range(1, column_set[0] + 1))
+            for column_num in column_set:
+                side_bucket = buckets.setdefault(side_num, {})
+                cell_rows = side_bucket.setdefault(column_num, [])
+                keys.setdefault((side_num, column_num), _photo_lookup_key(row))
+                cell_rows.append(row)
+
+    sides: list[Side] = []
+    for side_num in sorted(buckets):
+        columns: list[Column] = []
+        for column_num in sorted(buckets[side_num]):
+            cell_rows = buckets[side_num][column_num][-_MAX_CELLS_PER_COLUMN:]
+            key = keys[side_num, column_num]
+            cells = [Cell(value=row.baby_zppk, photo_lookup_key=key) for row in cell_rows]
+            columns.append(Column(number=column_num, cells=cells))
+        sides.append(Side(number=side_num, columns=columns))
+    return sides
+
+
+def _photo_lookup_key(row: _Row) -> str:
+    """Build the design-image lookup key for a row."""
+    return " ".join(
+        (
+            row.logo_description[:7],
+            row.color_description.replace(",", ""),
+            row.team_key,
+        ),
     )

--- a/src/palletinator/inputs.py
+++ b/src/palletinator/inputs.py
@@ -1,0 +1,32 @@
+"""Input types for the pallet processor."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ColumnNames:
+    """Spreadsheet column headers the engine should read each field from.
+
+    A ``None`` entry means the field is not present in the export and a
+    sensible default will be used.
+    """
+
+    parent_zppk: str
+    baby_zppk: str
+    team_key: str
+    team_name: str
+    requested_pallet_count: str
+    color_description: str
+    logo_description: str
+    column: str
+    side: str
+    callout: str | None = None
+    date_column: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Request:
+    """A request to process a pallet program export."""
+
+    csv_data: str
+    column_names: ColumnNames

--- a/src/palletinator/models.py
+++ b/src/palletinator/models.py
@@ -1,0 +1,62 @@
+"""Output data model for processed pallets."""
+
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Any
+
+
+class PalletType(Enum):
+    """Type of pallet build."""
+
+    FULL = auto()
+    HALF = auto()
+    TOWER = auto()
+
+
+@dataclass(frozen=True, slots=True)
+class Cell:
+    """A single cell within a pallet column.
+
+    Attributes
+    ----------
+    value
+        The representation value displayed in the cell (the baby ZPPK).
+    photo_lookup_key
+        Key the caller uses to look up the design image for this cell.
+    extras
+        Open-ended metadata bag for caller-defined fields.
+    """
+
+    value: str
+    photo_lookup_key: str
+    extras: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class Column:
+    """A column on a pallet side, ordered top-to-bottom by size band."""
+
+    number: int
+    cells: list[Cell]
+
+
+@dataclass(frozen=True, slots=True)
+class Side:
+    """A side of a pallet, ordered left-to-right by column number."""
+
+    number: int
+    columns: list[Column]
+
+
+@dataclass(frozen=True, slots=True)
+class Pallet:
+    """A fully-resolved pallet build."""
+
+    zppk: str
+    team_key: str
+    team_name: str
+    callout: str
+    dc_target: str
+    pallet_type: PalletType
+    required_count: int
+    sides: list[Side]

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,145 @@
+"""Tests for the pallet processing engine."""
+
+from textwrap import dedent
+
+from palletinator import (
+    Cell,
+    ColumnNames,
+    PalletType,
+    Request,
+    process,
+)
+
+_COLUMN_NAMES = ColumnNames(
+    parent_zppk="parent",
+    baby_zppk="baby",
+    team_key="team_key",
+    team_name="team_name",
+    requested_pallet_count="count",
+    color_description="color",
+    logo_description="logo",
+    column="column",
+    side="side",
+    callout="callout",
+    date_column="dc",
+)
+
+
+def _request(csv_data: str) -> Request:
+    return Request(csv_data=dedent(csv_data).lstrip(), column_names=_COLUMN_NAMES)
+
+
+def test_process_returns_one_pallet_with_expected_top_level_fields() -> None:
+    csv_data = """\
+        parent,baby,team_key,team_name,count,color,logo,column,side,callout,dc
+        PZ-1,BZ-A,TK,Team Name,0,Red,LogoText,1,1,No,
+        PZ-1,BZ-B,TK,Team Name,0,Red,LogoText,1,1,No,
+        PZ-1,BZ-C,TK,Team Name,0,Red,LogoText,1,1,No,
+        PZ-1,BZ-D,TK,Team Name,0,Red,LogoText,1,1,No,
+        ,,,,5,,,,,Yes,2026-06-15
+    """
+    [pallet] = process(_request(csv_data))
+
+    assert pallet.zppk == "PZ-1"
+    assert pallet.team_key == "TK"
+    assert pallet.team_name == "Team Name"
+    assert pallet.required_count == 5
+    assert pallet.pallet_type is PalletType.TOWER
+    assert pallet.callout == "CLC CREATIVE CORRUGATE"
+    assert pallet.dc_target == "2026-06-15"
+
+
+def test_cells_carry_value_and_photo_lookup_key() -> None:
+    csv_data = """\
+        parent,baby,team_key,team_name,count,color,logo,column,side,callout,dc
+        PZ-1,BZ-A,TK,Team Name,0,"Red, Bold",LogoTextLong,1,1,No,
+        PZ-1,BZ-B,TK,Team Name,0,"Red, Bold",LogoTextLong,1,1,No,
+        ,,,,1,,,,,No,
+    """
+    [pallet] = process(_request(csv_data))
+
+    [side] = pallet.sides
+    assert side.number == 1
+    [column] = side.columns
+    assert column.number == 1
+
+    assert [cell.value for cell in column.cells] == ["BZ-A", "BZ-B"]
+    expected_key = "LogoTex Red Bold TK"
+    for cell in column.cells:
+        assert cell.photo_lookup_key == expected_key
+        assert cell.extras == {}
+
+
+def test_column_truncates_to_last_four_cells() -> None:
+    csv_data = """\
+        parent,baby,team_key,team_name,count,color,logo,column,side,callout,dc
+        PZ,B1,TK,Team,0,Red,Logo,1,1,No,
+        PZ,B2,TK,Team,0,Red,Logo,1,1,No,
+        PZ,B3,TK,Team,0,Red,Logo,1,1,No,
+        PZ,B4,TK,Team,0,Red,Logo,1,1,No,
+        PZ,B5,TK,Team,0,Red,Logo,1,1,No,
+        ,,,,1,,,,,No,
+    """
+    [pallet] = process(_request(csv_data))
+    [side] = pallet.sides
+    [column] = side.columns
+
+    assert [cell.value for cell in column.cells] == ["B2", "B3", "B4", "B5"]
+
+
+def test_extras_dict_is_independent_per_cell() -> None:
+    csv_data = """\
+        parent,baby,team_key,team_name,count,color,logo,column,side,callout,dc
+        PZ,B1,TK,Team,0,Red,Logo,1,1,No,
+        PZ,B2,TK,Team,0,Red,Logo,1,1,No,
+        ,,,,1,,,,,No,
+    """
+    [pallet] = process(_request(csv_data))
+    [side] = pallet.sides
+    [column] = side.columns
+
+    column.cells[0].extras["image_b64"] = "abc"
+    assert column.cells[1].extras == {}
+
+
+def test_column_five_alternates_per_side() -> None:
+    csv_data = """\
+        parent,baby,team_key,team_name,count,color,logo,column,side,callout,dc
+        PZ,B1,TK,Team,0,Red,Logo,5,12,No,
+        ,,,,1,,,,,No,
+    """
+    [pallet] = process(_request(csv_data))
+
+    sides = {side.number: side for side in pallet.sides}
+    assert set(sides) == {1, 2}
+
+    assert [column.number for column in sides[1].columns] == [1, 2, 3]
+    assert [column.number for column in sides[2].columns] == [1, 2]
+
+
+def test_multiple_pallets_split_on_nonzero_count() -> None:
+    csv_data = """\
+        parent,baby,team_key,team_name,count,color,logo,column,side,callout,dc
+        PZ-A,BA1,TKA,Team A,0,Red,Logo,1,1,No,
+        ,,,,3,,,,,No,
+        PZ-B,BB1,TKB,Team B,0,Blue,Logo,1,1,Yes,
+        ,,,,7,,,,,Yes,
+    """
+    pallets = process(_request(csv_data))
+
+    assert len(pallets) == 2
+    assert pallets[0].zppk == "PZ-A"
+    assert pallets[0].team_key == "TKA"
+    assert pallets[0].required_count == 3
+    assert pallets[0].callout == ""
+    assert pallets[1].zppk == "PZ-B"
+    assert pallets[1].team_key == "TKB"
+    assert pallets[1].required_count == 7
+    assert pallets[1].callout == "CLC CREATIVE CORRUGATE"
+
+
+def test_cell_is_constructible_directly_with_extras() -> None:
+    cell = Cell(value="X", photo_lookup_key="K", extras={"size": "M"})
+    assert cell.value == "X"
+    assert cell.photo_lookup_key == "K"
+    assert cell.extras == {"size": "M"}


### PR DESCRIPTION
## Summary

Refactored the pallet processing engine to be a pure data transformation layer that accepts CSV input and returns structured pallet objects, removing all I/O operations (database queries, image fetching, PDF rendering, and email sending).

## Key Changes

- **Separated concerns**: Extracted the core CSV-to-pallet transformation logic into a focused `process()` function that performs no I/O
- **New data models**: Created `models.py` with clean output types (`Pallet`, `Side`, `Column`, `Cell`) that callers can use for downstream processing
- **New input types**: Created `inputs.py` with `Request` and `ColumnNames` types for explicit API contracts
- **Removed I/O operations**:
  - Removed database queries for design lookups
  - Removed image fetching and base64 encoding
  - Removed PDF generation and email sending
  - Removed template rendering
- **Improved data structure**: Cells now carry a `photo_lookup_key` for caller-driven image resolution and an `extras` dict for extensibility
- **Cleaner API**: Simplified function signatures and removed type: ignore comments by using proper type hints
- **Comprehensive tests**: Added 145 lines of test coverage for the core processing logic

## Implementation Details

- The engine now delegates image lookup to callers via the `photo_lookup_key` field on each `Cell`
- Column truncation (max 4 cells) and the "column 5" alternation logic are preserved
- Row grouping on non-zero `requested_pallet_count` remains unchanged
- All downstream I/O (image fetching, PDF generation, email) becomes the caller's responsibility

https://claude.ai/code/session_01QdjAnYAdubwbphqrY2So3G