### PR TITLE
Refactor engine from CSV processor to pallet builder

### DIFF
--- a/src/palletinator/__init__.py
+++ b/src/palletinator/__init__.py
@@ -1,16 +1,15 @@
-"""Pallet-inator: a structured-data pallet program processor."""
+"""Pallet-inator: a library for building structured pallet data."""
 
-from palletinator.engine import process
-from palletinator.inputs import ColumnNames, Request
+from palletinator.engine import build_pallet
+from palletinator.inputs import CellPlacement
 from palletinator.models import Cell, Column, Pallet, PalletType, Side
 
 __all__ = [
     "Cell",
+    "CellPlacement",
     "Column",
-    "ColumnNames",
     "Pallet",
     "PalletType",
-    "Request",
     "Side",
-    "process",
+    "build_pallet",
 ]

--- a/src/palletinator/__init__.py
+++ b/src/palletinator/__init__.py
@@ -2,14 +2,13 @@
 
 from palletinator.engine import build_pallet
 from palletinator.inputs import CellPlacement
-from palletinator.models import Cell, Column, Pallet, PalletType, Side
+from palletinator.models import Cell, Column, Pallet, Side
 
 __all__ = [
     "Cell",
     "CellPlacement",
     "Column",
     "Pallet",
-    "PalletType",
     "Side",
     "build_pallet",
 ]

--- a/src/palletinator/engine.py
+++ b/src/palletinator/engine.py
@@ -13,13 +13,10 @@ from palletinator.models import Cell, Column, Pallet, Side
 if TYPE_CHECKING:
     from palletinator.inputs import CellPlacement
 
-DEFAULT_MAX_CELLS_PER_COLUMN = 4
-
 
 def build_pallet(
     placements: list[CellPlacement],
     *,
-    max_cells_per_column: int = DEFAULT_MAX_CELLS_PER_COLUMN,
     extras: dict[str, Any] | None = None,
 ) -> Pallet:
     """Build a pallet from a list of cell placements.
@@ -29,9 +26,6 @@ def build_pallet(
     placements
         The cells to place. Each placement is materialised into one
         ``Cell`` per ``(side, column)`` coordinate it specifies.
-    max_cells_per_column
-        Cap on the number of cells per column. The most recently placed
-        cells win when the cap is exceeded.
     extras
         Open-ended metadata bag attached to the resulting ``Pallet``.
 
@@ -50,8 +44,7 @@ def build_pallet(
     for side_num in sorted(buckets):
         columns: list[Column] = []
         for column_num in sorted(buckets[side_num]):
-            kept = buckets[side_num][column_num][-max_cells_per_column:]
-            cells = [Cell(value=p.value, extras=dict(p.extras)) for p in kept]
+            cells = [Cell(value=p.value, extras=dict(p.extras)) for p in buckets[side_num][column_num]]
             columns.append(Column(number=column_num, cells=cells))
         sides.append(Side(number=side_num, columns=columns))
 

--- a/src/palletinator/engine.py
+++ b/src/palletinator/engine.py
@@ -2,13 +2,13 @@
 
 Bucket caller-supplied cell placements into a structured `Pallet` of
 sides, columns, and cells. The engine performs no I/O and applies no
-business rules: callers decide where each cell goes, what extra
-metadata it carries, and what pallet type the build represents.
+business rules: callers decide where each cell goes and what extra
+metadata it carries.
 """
 
 from typing import TYPE_CHECKING, Any
 
-from palletinator.models import Cell, Column, Pallet, PalletType, Side
+from palletinator.models import Cell, Column, Pallet, Side
 
 if TYPE_CHECKING:
     from palletinator.inputs import CellPlacement
@@ -19,7 +19,6 @@ DEFAULT_MAX_CELLS_PER_COLUMN = 4
 def build_pallet(
     placements: list[CellPlacement],
     *,
-    pallet_type: PalletType = PalletType.TOWER,
     max_cells_per_column: int = DEFAULT_MAX_CELLS_PER_COLUMN,
     extras: dict[str, Any] | None = None,
 ) -> Pallet:
@@ -30,8 +29,6 @@ def build_pallet(
     placements
         The cells to place. Each placement is materialised into one
         ``Cell`` per ``(side, column)`` coordinate it specifies.
-    pallet_type
-        The build type for the resulting pallet.
     max_cells_per_column
         Cap on the number of cells per column. The most recently placed
         cells win when the cap is exceeded.
@@ -59,7 +56,6 @@ def build_pallet(
         sides.append(Side(number=side_num, columns=columns))
 
     return Pallet(
-        pallet_type=pallet_type,
         sides=sides,
         extras=dict(extras) if extras else {},
     )

--- a/src/palletinator/engine.py
+++ b/src/palletinator/engine.py
@@ -1,162 +1,65 @@
-"""Pallet processing engine.
+"""Pallet building engine.
 
-Turns a pallet-program CSV export into a structured list of `Pallet`
-objects. The engine performs no I/O: it does not contact a database,
-fetch images, render PDFs, or send mail. Callers are responsible for
-enriching cells (using each cell's ``photo_lookup_key``) and for any
-downstream presentation.
+Bucket caller-supplied cell placements into a structured `Pallet` of
+sides, columns, and cells. The engine performs no I/O and applies no
+business rules: callers decide where each cell goes, what extra
+metadata it carries, and what pallet type the build represents.
 """
 
-import csv
-from dataclasses import dataclass
-from io import StringIO
-from typing import TYPE_CHECKING, Self
+from typing import TYPE_CHECKING, Any
 
 from palletinator.models import Cell, Column, Pallet, PalletType, Side
 
 if TYPE_CHECKING:
-    from palletinator.inputs import ColumnNames, Request
+    from palletinator.inputs import CellPlacement
 
-_FIVE_COLUMN_TRIGGER = 5
-_MAX_CELLS_PER_COLUMN = 4
+DEFAULT_MAX_CELLS_PER_COLUMN = 4
 
 
-def process(request: Request) -> list[Pallet]:
-    """Process a pallet-program CSV export into structured pallet data.
+def build_pallet(
+    placements: list[CellPlacement],
+    *,
+    pallet_type: PalletType = PalletType.TOWER,
+    max_cells_per_column: int = DEFAULT_MAX_CELLS_PER_COLUMN,
+    extras: dict[str, Any] | None = None,
+) -> Pallet:
+    """Build a pallet from a list of cell placements.
 
     Parameters
     ----------
-    request
-        The CSV payload and the column-name mapping describing where
-        each logical field lives in the export.
+    placements
+        The cells to place. Each placement is materialised into one
+        ``Cell`` per ``(side, column)`` coordinate it specifies.
+    pallet_type
+        The build type for the resulting pallet.
+    max_cells_per_column
+        Cap on the number of cells per column. The most recently placed
+        cells win when the cap is exceeded.
+    extras
+        Open-ended metadata bag attached to the resulting ``Pallet``.
 
     Returns
     -------
-    list[Pallet]
-        One `Pallet` per row group in the export.
+    Pallet
+        A pallet whose sides and columns are sorted by number.
     """
-    raw_rows = list(csv.DictReader(StringIO(request.csv_data)))
-    rows = [_Row.from_dict(raw, request.column_names) for raw in raw_rows]
-    return [_build_pallet(group) for group in _group_rows(rows)]
-
-
-@dataclass(frozen=True, slots=True)
-class _Row:
-    """An internal parsed CSV row."""
-
-    parent_zppk: str
-    baby_zppk: str
-    team_key: str
-    team_name: str
-    requested_pallet_count: int
-    callout: str
-    dc_target: str
-    color_description: str
-    logo_description: str
-    sides: list[int]
-    columns: list[int]
-
-    @classmethod
-    def from_dict(cls: type[Self], data: dict[str, str], names: ColumnNames) -> Self:
-        """Build a row from a `csv.DictReader` record."""
-        callout = ""
-        if names.callout is not None and data.get(names.callout) == "Yes":
-            callout = "CLC CREATIVE CORRUGATE"
-
-        dc_target = ""
-        if names.date_column is not None:
-            dc_target = data.get(names.date_column) or ""
-
-        return cls(
-            parent_zppk=data.get(names.parent_zppk) or "",
-            baby_zppk=data.get(names.baby_zppk) or "",
-            team_key=data.get(names.team_key) or "",
-            team_name=data.get(names.team_name) or "",
-            requested_pallet_count=int(data.get(names.requested_pallet_count) or 0),
-            callout=callout,
-            dc_target=dc_target,
-            color_description=data.get(names.color_description) or "",
-            logo_description=data.get(names.logo_description) or "",
-            sides=_extract_numbers(data.get(names.side) or "1"),
-            columns=_extract_numbers(data.get(names.column) or ""),
-        )
-
-
-def _extract_numbers(text: str) -> list[int]:
-    """Pull the digit characters out of `text` as a list of single-digit ints."""
-    return [int(char) for char in text if char.isdigit()]
-
-
-def _group_rows(rows: list[_Row]) -> list[list[_Row]]:
-    """Split rows into groups, terminating on a non-zero `requested_pallet_count`."""
-    groups: list[list[_Row]] = []
-    current: list[_Row] = []
-    for row in rows:
-        current.append(row)
-        if row.requested_pallet_count != 0:
-            groups.append(current)
-            current = []
-    return groups
-
-
-def _build_pallet(group: list[_Row]) -> Pallet:
-    """Build a `Pallet` from a single row group."""
-    last = group[-1]
-    header = group[-2] if len(group) > 1 else last
-    body = group[:-1] if len(group) > 1 else group
-
-    return Pallet(
-        zppk=header.parent_zppk,
-        team_key=header.team_key,
-        team_name=header.team_name,
-        callout=last.callout,
-        dc_target=last.dc_target,
-        pallet_type=PalletType.TOWER,
-        required_count=last.requested_pallet_count,
-        sides=_build_sides(body),
-    )
-
-
-def _build_sides(rows: list[_Row]) -> list[Side]:
-    """Bucket rows by `(side, column)` and emit `Side` objects in order."""
-    buckets: dict[int, dict[int, list[_Row]]] = {}
-    keys: dict[tuple[int, int], str] = {}
-    repeat_columns = False
-    for row in rows:
-        for side_num in row.sides:
-            if row.columns and row.columns[0] == _FIVE_COLUMN_TRIGGER:
-                repeat_columns = True
-                column_set = [2] if side_num % 2 == 0 else [3]
-            else:
-                column_set = row.columns
-            if not column_set:
-                continue
-            if repeat_columns:
-                column_set = list(range(1, column_set[0] + 1))
-            for column_num in column_set:
-                side_bucket = buckets.setdefault(side_num, {})
-                cell_rows = side_bucket.setdefault(column_num, [])
-                keys.setdefault((side_num, column_num), _photo_lookup_key(row))
-                cell_rows.append(row)
+    buckets: dict[int, dict[int, list[CellPlacement]]] = {}
+    for placement in placements:
+        for side_num in placement.sides:
+            for column_num in placement.columns:
+                buckets.setdefault(side_num, {}).setdefault(column_num, []).append(placement)
 
     sides: list[Side] = []
     for side_num in sorted(buckets):
         columns: list[Column] = []
         for column_num in sorted(buckets[side_num]):
-            cell_rows = buckets[side_num][column_num][-_MAX_CELLS_PER_COLUMN:]
-            key = keys[side_num, column_num]
-            cells = [Cell(value=row.baby_zppk, photo_lookup_key=key) for row in cell_rows]
+            kept = buckets[side_num][column_num][-max_cells_per_column:]
+            cells = [Cell(value=p.value, extras=dict(p.extras)) for p in kept]
             columns.append(Column(number=column_num, cells=cells))
         sides.append(Side(number=side_num, columns=columns))
-    return sides
 
-
-def _photo_lookup_key(row: _Row) -> str:
-    """Build the design-image lookup key for a row."""
-    return " ".join(
-        (
-            row.logo_description[:7],
-            row.color_description.replace(",", ""),
-            row.team_key,
-        ),
+    return Pallet(
+        pallet_type=pallet_type,
+        sides=sides,
+        extras=dict(extras) if extras else {},
     )

--- a/src/palletinator/inputs.py
+++ b/src/palletinator/inputs.py
@@ -1,32 +1,28 @@
-"""Input types for the pallet processor."""
+"""Input types for the pallet builder."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Any
 
 
 @dataclass(frozen=True, slots=True)
-class ColumnNames:
-    """Spreadsheet column headers the engine should read each field from.
+class CellPlacement:
+    """Specification for where a cell goes on a pallet build.
 
-    A ``None`` entry means the field is not present in the export and a
-    sensible default will be used.
+    Attributes
+    ----------
+    value
+        The value displayed in the resulting cell.
+    sides
+        Side numbers the cell appears on.
+    columns
+        Column numbers (within each side) the cell appears in.
+    extras
+        Open-ended metadata bag for caller-defined fields. A copy is
+        attached to every emitted ``Cell`` so callers can mutate per-cell
+        state without cross-talk.
     """
 
-    parent_zppk: str
-    baby_zppk: str
-    team_key: str
-    team_name: str
-    requested_pallet_count: str
-    color_description: str
-    logo_description: str
-    column: str
-    side: str
-    callout: str | None = None
-    date_column: str | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class Request:
-    """A request to process a pallet program export."""
-
-    csv_data: str
-    column_names: ColumnNames
+    value: str
+    sides: list[int]
+    columns: list[int]
+    extras: dict[str, Any] = field(default_factory=dict)

--- a/src/palletinator/models.py
+++ b/src/palletinator/models.py
@@ -1,4 +1,4 @@
-"""Output data model for processed pallets."""
+"""Output data model for built pallets."""
 
 from dataclasses import dataclass, field
 from enum import Enum, auto
@@ -20,21 +20,18 @@ class Cell:
     Attributes
     ----------
     value
-        The representation value displayed in the cell (the baby ZPPK).
-    photo_lookup_key
-        Key the caller uses to look up the design image for this cell.
+        The value displayed in the cell.
     extras
         Open-ended metadata bag for caller-defined fields.
     """
 
     value: str
-    photo_lookup_key: str
     extras: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True, slots=True)
 class Column:
-    """A column on a pallet side, ordered top-to-bottom by size band."""
+    """A column on a pallet side, ordered top-to-bottom."""
 
     number: int
     cells: list[Cell]
@@ -50,13 +47,18 @@ class Side:
 
 @dataclass(frozen=True, slots=True)
 class Pallet:
-    """A fully-resolved pallet build."""
+    """A fully-resolved pallet build.
 
-    zppk: str
-    team_key: str
-    team_name: str
-    callout: str
-    dc_target: str
+    Attributes
+    ----------
+    pallet_type
+        The build type (full, half, tower).
+    sides
+        Sides on the pallet, ordered by side number.
+    extras
+        Open-ended metadata bag for caller-defined fields.
+    """
+
     pallet_type: PalletType
-    required_count: int
     sides: list[Side]
+    extras: dict[str, Any] = field(default_factory=dict)

--- a/src/palletinator/models.py
+++ b/src/palletinator/models.py
@@ -1,16 +1,7 @@
 """Output data model for built pallets."""
 
 from dataclasses import dataclass, field
-from enum import Enum, auto
 from typing import Any
-
-
-class PalletType(Enum):
-    """Type of pallet build."""
-
-    FULL = auto()
-    HALF = auto()
-    TOWER = auto()
 
 
 @dataclass(frozen=True, slots=True)
@@ -51,14 +42,11 @@ class Pallet:
 
     Attributes
     ----------
-    pallet_type
-        The build type (full, half, tower).
     sides
         Sides on the pallet, ordered by side number.
     extras
         Open-ended metadata bag for caller-defined fields.
     """
 
-    pallet_type: PalletType
     sides: list[Side]
     extras: dict[str, Any] = field(default_factory=dict)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -79,22 +79,13 @@ def test_cell_extras_are_copied_from_placement() -> None:
     assert source == {"k": "v"}
 
 
-def test_column_truncates_to_max_cells_per_column_default_four() -> None:
+def test_column_keeps_all_placed_cells_in_order() -> None:
     placements = [CellPlacement(value=f"B{i}", sides=[1], columns=[1]) for i in range(1, 6)]
     pallet = build_pallet(placements)
 
     [side] = pallet.sides
     [column] = side.columns
-    assert [cell.value for cell in column.cells] == ["B2", "B3", "B4", "B5"]
-
-
-def test_max_cells_per_column_is_configurable() -> None:
-    placements = [CellPlacement(value=f"B{i}", sides=[1], columns=[1]) for i in range(1, 5)]
-    pallet = build_pallet(placements, max_cells_per_column=2)
-
-    [side] = pallet.sides
-    [column] = side.columns
-    assert [cell.value for cell in column.cells] == ["B3", "B4"]
+    assert [cell.value for cell in column.cells] == ["B1", "B2", "B3", "B4", "B5"]
 
 
 def test_placement_with_multiple_sides_and_columns_fans_out() -> None:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,100 +1,77 @@
-"""Tests for the pallet processing engine."""
-
-from textwrap import dedent
+"""Tests for the pallet builder engine."""
 
 from palletinator import (
     Cell,
-    ColumnNames,
+    CellPlacement,
+    Pallet,
     PalletType,
-    Request,
-    process,
-)
-
-_COLUMN_NAMES = ColumnNames(
-    parent_zppk="parent",
-    baby_zppk="baby",
-    team_key="team_key",
-    team_name="team_name",
-    requested_pallet_count="count",
-    color_description="color",
-    logo_description="logo",
-    column="column",
-    side="side",
-    callout="callout",
-    date_column="dc",
+    build_pallet,
 )
 
 
-def _request(csv_data: str) -> Request:
-    return Request(csv_data=dedent(csv_data).lstrip(), column_names=_COLUMN_NAMES)
+def test_build_pallet_returns_pallet_with_pallet_type_and_extras() -> None:
+    pallet = build_pallet(
+        [CellPlacement(value="X", sides=[1], columns=[1])],
+        pallet_type=PalletType.HALF,
+        extras={"order_id": "PZ-1"},
+    )
+
+    assert isinstance(pallet, Pallet)
+    assert pallet.pallet_type is PalletType.HALF
+    assert pallet.extras == {"order_id": "PZ-1"}
 
 
-def test_process_returns_one_pallet_with_expected_top_level_fields() -> None:
-    csv_data = """\
-        parent,baby,team_key,team_name,count,color,logo,column,side,callout,dc
-        PZ-1,BZ-A,TK,Team Name,0,Red,LogoText,1,1,No,
-        PZ-1,BZ-B,TK,Team Name,0,Red,LogoText,1,1,No,
-        PZ-1,BZ-C,TK,Team Name,0,Red,LogoText,1,1,No,
-        PZ-1,BZ-D,TK,Team Name,0,Red,LogoText,1,1,No,
-        ,,,,5,,,,,Yes,2026-06-15
-    """
-    [pallet] = process(_request(csv_data))
-
-    assert pallet.zppk == "PZ-1"
-    assert pallet.team_key == "TK"
-    assert pallet.team_name == "Team Name"
-    assert pallet.required_count == 5
+def test_pallet_type_defaults_to_tower() -> None:
+    pallet = build_pallet([CellPlacement(value="X", sides=[1], columns=[1])])
     assert pallet.pallet_type is PalletType.TOWER
-    assert pallet.callout == "CLC CREATIVE CORRUGATE"
-    assert pallet.dc_target == "2026-06-15"
 
 
-def test_cells_carry_value_and_photo_lookup_key() -> None:
-    csv_data = """\
-        parent,baby,team_key,team_name,count,color,logo,column,side,callout,dc
-        PZ-1,BZ-A,TK,Team Name,0,"Red, Bold",LogoTextLong,1,1,No,
-        PZ-1,BZ-B,TK,Team Name,0,"Red, Bold",LogoTextLong,1,1,No,
-        ,,,,1,,,,,No,
-    """
-    [pallet] = process(_request(csv_data))
+def test_pallet_extras_default_to_empty_dict() -> None:
+    pallet = build_pallet([CellPlacement(value="X", sides=[1], columns=[1])])
+    assert pallet.extras == {}
+
+
+def test_pallet_extras_dict_is_independent_per_pallet() -> None:
+    p1 = build_pallet([CellPlacement(value="X", sides=[1], columns=[1])])
+    p2 = build_pallet([CellPlacement(value="X", sides=[1], columns=[1])])
+
+    p1.extras["k"] = "v"
+    assert p2.extras == {}
+
+
+def test_pallet_extras_are_copied_from_input() -> None:
+    source = {"k": "v"}
+    pallet = build_pallet([CellPlacement(value="X", sides=[1], columns=[1])], extras=source)
+
+    pallet.extras["k"] = "other"
+    assert source == {"k": "v"}
+
+
+def test_cells_carry_value_and_extras() -> None:
+    pallet = build_pallet(
+        [
+            CellPlacement(value="A", sides=[1], columns=[1], extras={"key": "K"}),
+            CellPlacement(value="B", sides=[1], columns=[1], extras={"key": "K"}),
+        ],
+    )
 
     [side] = pallet.sides
     assert side.number == 1
     [column] = side.columns
     assert column.number == 1
 
-    assert [cell.value for cell in column.cells] == ["BZ-A", "BZ-B"]
-    expected_key = "LogoTex Red Bold TK"
+    assert [cell.value for cell in column.cells] == ["A", "B"]
     for cell in column.cells:
-        assert cell.photo_lookup_key == expected_key
-        assert cell.extras == {}
+        assert cell.extras == {"key": "K"}
 
 
-def test_column_truncates_to_last_four_cells() -> None:
-    csv_data = """\
-        parent,baby,team_key,team_name,count,color,logo,column,side,callout,dc
-        PZ,B1,TK,Team,0,Red,Logo,1,1,No,
-        PZ,B2,TK,Team,0,Red,Logo,1,1,No,
-        PZ,B3,TK,Team,0,Red,Logo,1,1,No,
-        PZ,B4,TK,Team,0,Red,Logo,1,1,No,
-        PZ,B5,TK,Team,0,Red,Logo,1,1,No,
-        ,,,,1,,,,,No,
-    """
-    [pallet] = process(_request(csv_data))
-    [side] = pallet.sides
-    [column] = side.columns
-
-    assert [cell.value for cell in column.cells] == ["B2", "B3", "B4", "B5"]
-
-
-def test_extras_dict_is_independent_per_cell() -> None:
-    csv_data = """\
-        parent,baby,team_key,team_name,count,color,logo,column,side,callout,dc
-        PZ,B1,TK,Team,0,Red,Logo,1,1,No,
-        PZ,B2,TK,Team,0,Red,Logo,1,1,No,
-        ,,,,1,,,,,No,
-    """
-    [pallet] = process(_request(csv_data))
+def test_cell_extras_dict_is_independent_per_cell() -> None:
+    pallet = build_pallet(
+        [
+            CellPlacement(value="A", sides=[1], columns=[1]),
+            CellPlacement(value="B", sides=[1], columns=[1]),
+        ],
+    )
     [side] = pallet.sides
     [column] = side.columns
 
@@ -102,44 +79,84 @@ def test_extras_dict_is_independent_per_cell() -> None:
     assert column.cells[1].extras == {}
 
 
-def test_column_five_alternates_per_side() -> None:
-    csv_data = """\
-        parent,baby,team_key,team_name,count,color,logo,column,side,callout,dc
-        PZ,B1,TK,Team,0,Red,Logo,5,12,No,
-        ,,,,1,,,,,No,
-    """
-    [pallet] = process(_request(csv_data))
+def test_cell_extras_are_copied_from_placement() -> None:
+    source = {"k": "v"}
+    pallet = build_pallet([CellPlacement(value="A", sides=[1], columns=[1], extras=source)])
+
+    pallet.sides[0].columns[0].cells[0].extras["k"] = "other"
+    assert source == {"k": "v"}
+
+
+def test_column_truncates_to_max_cells_per_column_default_four() -> None:
+    placements = [CellPlacement(value=f"B{i}", sides=[1], columns=[1]) for i in range(1, 6)]
+    pallet = build_pallet(placements)
+
+    [side] = pallet.sides
+    [column] = side.columns
+    assert [cell.value for cell in column.cells] == ["B2", "B3", "B4", "B5"]
+
+
+def test_max_cells_per_column_is_configurable() -> None:
+    placements = [CellPlacement(value=f"B{i}", sides=[1], columns=[1]) for i in range(1, 5)]
+    pallet = build_pallet(placements, max_cells_per_column=2)
+
+    [side] = pallet.sides
+    [column] = side.columns
+    assert [cell.value for cell in column.cells] == ["B3", "B4"]
+
+
+def test_placement_with_multiple_sides_and_columns_fans_out() -> None:
+    pallet = build_pallet([CellPlacement(value="X", sides=[1, 2], columns=[1, 2])])
 
     sides = {side.number: side for side in pallet.sides}
     assert set(sides) == {1, 2}
+    for side in sides.values():
+        assert [column.number for column in side.columns] == [1, 2]
+        for column in side.columns:
+            assert [cell.value for cell in column.cells] == ["X"]
 
-    assert [column.number for column in sides[1].columns] == [1, 2, 3]
-    assert [column.number for column in sides[2].columns] == [1, 2]
+
+def test_sides_and_columns_are_sorted_by_number() -> None:
+    pallet = build_pallet(
+        [
+            CellPlacement(value="A", sides=[3], columns=[2]),
+            CellPlacement(value="B", sides=[1], columns=[3]),
+            CellPlacement(value="C", sides=[1], columns=[1]),
+        ],
+    )
+
+    assert [side.number for side in pallet.sides] == [1, 3]
+    assert [column.number for column in pallet.sides[0].columns] == [1, 3]
 
 
-def test_multiple_pallets_split_on_nonzero_count() -> None:
-    csv_data = """\
-        parent,baby,team_key,team_name,count,color,logo,column,side,callout,dc
-        PZ-A,BA1,TKA,Team A,0,Red,Logo,1,1,No,
-        ,,,,3,,,,,No,
-        PZ-B,BB1,TKB,Team B,0,Blue,Logo,1,1,Yes,
-        ,,,,7,,,,,Yes,
-    """
-    pallets = process(_request(csv_data))
+def test_empty_placements_produces_empty_pallet() -> None:
+    pallet = build_pallet([])
+    assert pallet.sides == []
 
-    assert len(pallets) == 2
-    assert pallets[0].zppk == "PZ-A"
-    assert pallets[0].team_key == "TKA"
-    assert pallets[0].required_count == 3
-    assert pallets[0].callout == ""
-    assert pallets[1].zppk == "PZ-B"
-    assert pallets[1].team_key == "TKB"
-    assert pallets[1].required_count == 7
-    assert pallets[1].callout == "CLC CREATIVE CORRUGATE"
+
+def test_placement_with_empty_sides_or_columns_is_skipped() -> None:
+    pallet = build_pallet(
+        [
+            CellPlacement(value="A", sides=[], columns=[1]),
+            CellPlacement(value="B", sides=[1], columns=[]),
+        ],
+    )
+    assert pallet.sides == []
 
 
 def test_cell_is_constructible_directly_with_extras() -> None:
-    cell = Cell(value="X", photo_lookup_key="K", extras={"size": "M"})
+    cell = Cell(value="X", extras={"size": "M"})
     assert cell.value == "X"
-    assert cell.photo_lookup_key == "K"
     assert cell.extras == {"size": "M"}
+
+
+def test_cell_extras_default_to_empty_dict() -> None:
+    cell = Cell(value="X")
+    assert cell.extras == {}
+
+
+def test_pallet_is_constructible_directly_with_extras() -> None:
+    pallet = Pallet(pallet_type=PalletType.FULL, sides=[], extras={"order_id": "1"})
+    assert pallet.pallet_type is PalletType.FULL
+    assert pallet.sides == []
+    assert pallet.extras == {"order_id": "1"}

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -4,26 +4,18 @@ from palletinator import (
     Cell,
     CellPlacement,
     Pallet,
-    PalletType,
     build_pallet,
 )
 
 
-def test_build_pallet_returns_pallet_with_pallet_type_and_extras() -> None:
+def test_build_pallet_returns_pallet_with_extras() -> None:
     pallet = build_pallet(
         [CellPlacement(value="X", sides=[1], columns=[1])],
-        pallet_type=PalletType.HALF,
         extras={"order_id": "PZ-1"},
     )
 
     assert isinstance(pallet, Pallet)
-    assert pallet.pallet_type is PalletType.HALF
     assert pallet.extras == {"order_id": "PZ-1"}
-
-
-def test_pallet_type_defaults_to_tower() -> None:
-    pallet = build_pallet([CellPlacement(value="X", sides=[1], columns=[1])])
-    assert pallet.pallet_type is PalletType.TOWER
 
 
 def test_pallet_extras_default_to_empty_dict() -> None:
@@ -156,7 +148,6 @@ def test_cell_extras_default_to_empty_dict() -> None:
 
 
 def test_pallet_is_constructible_directly_with_extras() -> None:
-    pallet = Pallet(pallet_type=PalletType.FULL, sides=[], extras={"order_id": "1"})
-    assert pallet.pallet_type is PalletType.FULL
+    pallet = Pallet(sides=[], extras={"order_id": "1"})
     assert pallet.sides == []
     assert pallet.extras == {"order_id": "1"}


### PR DESCRIPTION
## Summary

This PR fundamentally refactors the pallet-inator library from a CSV processing engine into a simpler pallet building engine. The new design accepts caller-supplied cell placements and buckets them into a structured pallet, removing all CSV parsing, business logic, and domain-specific metadata.

## Key Changes

- **Replaced `process()` with `build_pallet()`**: The main entry point now takes a list of `CellPlacement` objects instead of CSV data, making the library domain-agnostic and testable without file I/O.

- **Introduced `CellPlacement` input type**: New dataclass that specifies where a cell goes (sides, columns) and what value/metadata it carries, replacing the complex CSV parsing and row grouping logic.

- **Simplified `Pallet` model**: Removed domain-specific fields (`zppk`, `team_key`, `team_name`, `callout`, `dc_target`, `pallet_type`, `required_count`) and replaced with a generic `extras` metadata bag. Pallets now only contain `sides` and `extras`.

- **Simplified `Cell` model**: Removed `photo_lookup_key` field. Cells now only carry `value` and `extras`, delegating image lookup responsibility to callers.

- **Removed CSV infrastructure**: Deleted `ColumnNames` and `Request` input types, CSV parsing logic, row grouping, and photo lookup key generation.

- **Removed `PalletType` enum**: No longer needed in the simplified model.

## Implementation Details

- The new `build_pallet()` function buckets placements by `(side, column)` coordinates and materializes cells in order, keeping all placed cells (no truncation).
- Sides and columns are automatically sorted by number in the output.
- Both `Pallet` and `Cell` extras dictionaries are copied from input to prevent cross-talk between instances.
- The engine applies no business rules—callers have full control over cell placement and metadata.

## Testing

All tests were rewritten to validate the new builder API, focusing on:
- Pallet and cell construction with extras
- Placement fan-out across multiple sides/columns
- Sorting of sides and columns
- Independence of extras dictionaries across instances

https://claude.ai/code/session_01B4yrWbjpXu17fpP1Hs1Def