### PR TITLE
Convert models to frozen pydantic; bump to 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,46 @@
 # Pallet-inator
 
-Coming soon! In the meantime, here's a pallet-pus (get it?)
+A library for building structured pallet data.
+
+Describe where each cell goes with `CellPlacement`s, and `build_pallet` assembles them
+into a `Pallet` of sides, columns, and cells — sorted by number, with cells kept in
+placement order. The engine performs no I/O and applies no business rules: callers
+decide where each cell goes and what extra metadata it carries. Every `Cell` and
+`Pallet` has an open-ended `extras` bag for caller-defined fields, so domain-specific
+data rides along without the library needing to know about it.
+
+## Usage
+
+```python
+from palletinator import CellPlacement, build_pallet
+
+placements = [
+    CellPlacement(value="A-1", sides=[1, 2], columns=[1], extras={"design": "D-100"}),
+    CellPlacement(value="A-2", sides=[1, 2], columns=[1], extras={"design": "D-101"}),
+    CellPlacement(value="B-1", sides=[1], columns=[2], extras={"design": "D-200"}),
+]
+
+pallet = build_pallet(placements, extras={"order_id": "PZ-1", "required_count": 4})
+
+for side in pallet.sides:
+    for column in side.columns:
+        for cell in column.cells:
+            print(side.number, column.number, cell.value, cell.extras)
+```
+
+## JSON serialization
+
+All models are [pydantic](https://docs.pydantic.dev/) models, so serialization comes
+built in — no custom methods:
+
+```python
+data = pallet.model_dump_json()
+restored = Pallet.model_validate_json(data)
+assert restored == pallet
+```
+
+---
+
+Here's a pallet-pus (get it?)
+
 ![palletpus](https://raw.githubusercontent.com/impressdesigns/palletinator/main/docs/static/palletpus.jpeg "Palletpus")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "palletinator"
-version = "0.1.0"
+version = "0.2.0"
 description = "Pallet-inator"
 authors = [
     { name = "Bradley Reynolds", email = "bradley.reynolds@tailstory.dev" },
@@ -8,7 +8,9 @@ authors = [
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.14"
-dependencies = []
+dependencies = [
+    "pydantic>=2.12",
+]
 
 [project.urls]
 repository = "https://github.com/tailstory-labs/palletinator"
@@ -70,6 +72,7 @@ convention = "numpy"
 
 [tool.mypy]
 pretty = true
+plugins = ["pydantic.mypy"]
 
 [tool.coverage.run]
 branch = true

--- a/src/palletinator/inputs.py
+++ b/src/palletinator/inputs.py
@@ -1,11 +1,11 @@
 """Input types for the pallet builder."""
 
-from dataclasses import dataclass, field
 from typing import Any
 
+from pydantic import BaseModel, ConfigDict, Field
 
-@dataclass(frozen=True, slots=True)
-class CellPlacement:
+
+class CellPlacement(BaseModel):
     """Specification for where a cell goes on a pallet build.
 
     Attributes
@@ -20,9 +20,16 @@ class CellPlacement:
         Open-ended metadata bag for caller-defined fields. A copy is
         attached to every emitted ``Cell`` so callers can mutate per-cell
         state without cross-talk.
+
+    Notes
+    -----
+    Serializable to and from JSON with pydantic's built-ins:
+    ``placement.model_dump_json()`` and ``CellPlacement.model_validate_json(data)``.
     """
+
+    model_config = ConfigDict(frozen=True)
 
     value: str
     sides: list[int]
     columns: list[int]
-    extras: dict[str, Any] = field(default_factory=dict)
+    extras: dict[str, Any] = Field(default_factory=dict)

--- a/src/palletinator/inputs.py
+++ b/src/palletinator/inputs.py
@@ -2,10 +2,10 @@
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, Field
 
 
-class CellPlacement(BaseModel):
+class CellPlacement(BaseModel, frozen=True):
     """Specification for where a cell goes on a pallet build.
 
     Attributes
@@ -26,8 +26,6 @@ class CellPlacement(BaseModel):
     Serializable to and from JSON with pydantic's built-ins:
     ``placement.model_dump_json()`` and ``CellPlacement.model_validate_json(data)``.
     """
-
-    model_config = ConfigDict(frozen=True)
 
     value: str
     sides: list[int]

--- a/src/palletinator/models.py
+++ b/src/palletinator/models.py
@@ -1,11 +1,11 @@
 """Output data model for built pallets."""
 
-from dataclasses import dataclass, field
 from typing import Any
 
+from pydantic import BaseModel, ConfigDict, Field
 
-@dataclass(frozen=True, slots=True)
-class Cell:
+
+class Cell(BaseModel):
     """A single cell within a pallet column.
 
     Attributes
@@ -14,30 +14,38 @@ class Cell:
         The value displayed in the cell.
     extras
         Open-ended metadata bag for caller-defined fields.
+
+    Notes
+    -----
+    Serializable to and from JSON with pydantic's built-ins:
+    ``cell.model_dump_json()`` and ``Cell.model_validate_json(data)``.
     """
 
+    model_config = ConfigDict(frozen=True)
+
     value: str
-    extras: dict[str, Any] = field(default_factory=dict)
+    extras: dict[str, Any] = Field(default_factory=dict)
 
 
-@dataclass(frozen=True, slots=True)
-class Column:
+class Column(BaseModel):
     """A column on a pallet side, with cells ordered top-to-bottom."""
+
+    model_config = ConfigDict(frozen=True)
 
     number: int
     cells: list[Cell]
 
 
-@dataclass(frozen=True, slots=True)
-class Side:
+class Side(BaseModel):
     """A side of a pallet, with columns ordered left-to-right by column number."""
+
+    model_config = ConfigDict(frozen=True)
 
     number: int
     columns: list[Column]
 
 
-@dataclass(frozen=True, slots=True)
-class Pallet:
+class Pallet(BaseModel):
     """A fully-resolved pallet build.
 
     Attributes
@@ -46,7 +54,14 @@ class Pallet:
         Sides on the pallet, ordered by side number.
     extras
         Open-ended metadata bag for caller-defined fields.
+
+    Notes
+    -----
+    Serializable to and from JSON with pydantic's built-ins:
+    ``pallet.model_dump_json()`` and ``Pallet.model_validate_json(data)``.
     """
 
+    model_config = ConfigDict(frozen=True)
+
     sides: list[Side]
-    extras: dict[str, Any] = field(default_factory=dict)
+    extras: dict[str, Any] = Field(default_factory=dict)

--- a/src/palletinator/models.py
+++ b/src/palletinator/models.py
@@ -2,10 +2,10 @@
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, Field
 
 
-class Cell(BaseModel):
+class Cell(BaseModel, frozen=True):
     """A single cell within a pallet column.
 
     Attributes
@@ -21,31 +21,25 @@ class Cell(BaseModel):
     ``cell.model_dump_json()`` and ``Cell.model_validate_json(data)``.
     """
 
-    model_config = ConfigDict(frozen=True)
-
     value: str
     extras: dict[str, Any] = Field(default_factory=dict)
 
 
-class Column(BaseModel):
+class Column(BaseModel, frozen=True):
     """A column on a pallet side, with cells ordered top-to-bottom."""
-
-    model_config = ConfigDict(frozen=True)
 
     number: int
     cells: list[Cell]
 
 
-class Side(BaseModel):
+class Side(BaseModel, frozen=True):
     """A side of a pallet, with columns ordered left-to-right by column number."""
-
-    model_config = ConfigDict(frozen=True)
 
     number: int
     columns: list[Column]
 
 
-class Pallet(BaseModel):
+class Pallet(BaseModel, frozen=True):
     """A fully-resolved pallet build.
 
     Attributes
@@ -60,8 +54,6 @@ class Pallet(BaseModel):
     Serializable to and from JSON with pydantic's built-ins:
     ``pallet.model_dump_json()`` and ``Pallet.model_validate_json(data)``.
     """
-
-    model_config = ConfigDict(frozen=True)
 
     sides: list[Side]
     extras: dict[str, Any] = Field(default_factory=dict)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,47 @@
+"""Tests for the pydantic data models."""
+
+import pytest
+from pydantic import ValidationError
+
+from palletinator import Cell, CellPlacement, Pallet, build_pallet
+
+
+def test_pallet_json_round_trip() -> None:
+    pallet = build_pallet(
+        [
+            CellPlacement(value="A", sides=[1, 2], columns=[1], extras={"code": "K1"}),
+            CellPlacement(value="B", sides=[1], columns=[1, 2], extras={"code": "K2"}),
+        ],
+        extras={"order_id": "PZ-1", "required_count": 4},
+    )
+
+    assert Pallet.model_validate_json(pallet.model_dump_json()) == pallet
+
+
+def test_cell_placement_json_round_trip() -> None:
+    placement = CellPlacement(value="A", sides=[1, 3], columns=[2], extras={"code": "K1"})
+    assert CellPlacement.model_validate_json(placement.model_dump_json()) == placement
+
+
+def test_cell_is_frozen() -> None:
+    cell = Cell(value="X")
+    with pytest.raises(ValidationError):
+        cell.value = "Y"
+
+
+def test_pallet_is_frozen() -> None:
+    pallet = Pallet(sides=[])
+    with pytest.raises(ValidationError):
+        pallet.sides = []
+
+
+def test_cell_placement_is_frozen() -> None:
+    placement = CellPlacement(value="X", sides=[1], columns=[1])
+    with pytest.raises(ValidationError):
+        placement.value = "Y"
+
+
+def test_frozen_models_still_allow_in_place_extras_mutation() -> None:
+    pallet = Pallet(sides=[], extras={})
+    pallet.extras["k"] = "v"
+    assert pallet.extras == {"k": "v"}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -26,19 +26,19 @@ def test_cell_placement_json_round_trip() -> None:
 def test_cell_is_frozen() -> None:
     cell = Cell(value="X")
     with pytest.raises(ValidationError):
-        cell.value = "Y"
+        cell.value = "Y"  # ty: ignore[invalid-assignment] -- asserting the frozen model rejects this at runtime
 
 
 def test_pallet_is_frozen() -> None:
     pallet = Pallet(sides=[])
     with pytest.raises(ValidationError):
-        pallet.sides = []
+        pallet.sides = []  # ty: ignore[invalid-assignment] -- asserting the frozen model rejects this at runtime
 
 
 def test_cell_placement_is_frozen() -> None:
     placement = CellPlacement(value="X", sides=[1], columns=[1])
     with pytest.raises(ValidationError):
-        placement.value = "Y"
+        placement.value = "Y"  # ty: ignore[invalid-assignment] -- asserting the frozen model rejects this at runtime
 
 
 def test_frozen_models_still_allow_in_place_extras_mutation() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -54,6 +54,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "argcomplete"
 version = "3.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -487,8 +496,11 @@ wheels = [
 
 [[package]]
 name = "palletinator"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
+dependencies = [
+    { name = "pydantic" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -512,6 +524,7 @@ tests = [
 ]
 
 [package.metadata]
+requires-dist = [{ name = "pydantic", specifier = ">=2.12" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -583,6 +596,62 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/79/fa/43b1d761381dc1c7eeb8f2235c66e902970d4b2bff2dec0f02836c085769/prek-0.4.5-py3-none-win32.whl", hash = "sha256:7546989b2403c96137bd79d19ebfe21facb87266cefe819db2458c3b9b23f350", size = 5287935, upload-time = "2026-06-15T11:36:20.293Z" },
     { url = "https://files.pythonhosted.org/packages/f5/fe/59b5eb3124f5a4cc255a93857b9ab42402635b273f157e91de23bfa40e8f/prek-0.4.5-py3-none-win_amd64.whl", hash = "sha256:8b2ac9227504371d97338215b344184cb0b31ca94113515a3a90c509c6c5a707", size = 5682560, upload-time = "2026-06-15T11:36:25.865Z" },
     { url = "https://files.pythonhosted.org/packages/97/0e/589ff0eab9034909b1ec8654ee03483797305fb743b3554ce6140d82da9d/prek-0.4.5-py3-none-win_arm64.whl", hash = "sha256:646a86a1a082dbd99fed96314b1064f5644bb34c1f4037a63547a18e2160fb86", size = 5509019, upload-time = "2026-06-15T11:36:46.595Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
 ]
 
 [[package]]
@@ -891,6 +960,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Convert the data models from frozen dataclasses to frozen pydantic models, giving JSON serialization for free, and add a real README. Bumps the package to `0.2.0`.

## Why

Consumers want to serialize built pallets to/from JSON. Rather than hand-write `to_dict`/`from_dict` methods, pydantic provides `model_dump_json()` / `model_validate_json()` out of the box. The models stay frozen and the public API is unchanged.

## Changes

- `src/palletinator/models.py`, `src/palletinator/inputs.py`: `Cell`, `Column`, `Side`, `Pallet`, and `CellPlacement` become `pydantic.BaseModel` with `ConfigDict(frozen=True)`. Field names, order, and defaults are preserved; `extras` still defaults to an independent dict per instance. Docstrings gain a `Notes` section documenting JSON round-tripping.
- `engine.py`: unchanged — construction was already keyword-based.
- `pyproject.toml`: version `0.1.0` → `0.2.0`; adds `pydantic>=2.12` (first release supporting the package's Python 3.14 floor) as the first runtime dependency; adds the `pydantic.mypy` plugin. `uv.lock` regenerated.
- `tests/test_models.py` (new): JSON round-trip of a built `Pallet` and a `CellPlacement`, frozen-ness (attribute assignment raises `ValidationError`), and that in-place `extras` mutation still works.
- `README.md`: replaced the placeholder with a real description, a usage example, and a JSON serialization note (palletpus retained).

The library stays domain-agnostic — no dataset-specific vocabulary. The engine performs no I/O and applies no business rules.

## Compatibility

pydantic requires keyword construction, so positional `Cell("X")` no longer works. Nothing in-repo constructs positionally; the `0.1.0` → `0.2.0` bump signals the change.

## Verification

`nox -s tests` (21 passing: 15 existing engine tests unchanged + 6 new model tests) and `nox -s lints` (prek, ruff, mypy --strict, ty) both green.

## Note

One of three related PRs; `impressdesigns/scripts` pins `palletinator>=0.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TNmRTjtua7oPSph8vjZxWt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TNmRTjtua7oPSph8vjZxWt)_